### PR TITLE
Fix for Phoenix shapes.

### DIFF
--- a/shapes/Collection.cs
+++ b/shapes/Collection.cs
@@ -190,7 +190,7 @@ namespace Weland {
 	}
 
 	public System.Drawing.Bitmap GetShape(byte ColorTableIndex, byte BitmapIndex) {
-	    Bitmap bitmap = Type == CollectionType.Wall ? bitmaps[lowLevelShapes[BitmapIndex].BitmapIndex] : bitmaps[BitmapIndex];
+	    Bitmap bitmap = Type == CollectionType.Wall && BitmapIndex < lowLevelShapeCount - 1 ? bitmaps[lowLevelShapes[BitmapIndex].BitmapIndex] : bitmaps[BitmapIndex];
 	    ColorValue[] colorTable = colorTables[ColorTableIndex];
 	    Color[] colors = new Color[colorTable.Length];
 	    for (int i = 0; i < colorTable.Length; ++i) {


### PR DESCRIPTION
Getting walls shapes from a collection will now use the passed bitmap index as-is if it is beyond the range of the lowLevelShapeCount (frames).